### PR TITLE
Fix normative vs non-normative references

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -1057,13 +1057,13 @@ Editorial Tweaks to HTML</h2>
 	that would be desirable to make to the [[HTML inline]]
 	in order to make it fully align it with what is covered here.
 
-	<ul>
+	<ul class="non-normative">
 		<li>
 			Remove the outdated informative description
 			of CSS annonymous box generation for ruby bases
 			in the following paragraph in [[html/rendering#phrasing-content-3]]:
 
-			<blockquote class="non-normative">
+			<blockquote>
 				For the purposes of the CSS ruby model,
 				runs of children of <{ruby}> elements
 				that are not <{rt}> or <{rp}> elements


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/html-ruby/pull/28.html" title="Last updated on Nov 17, 2025, 4:05 PM UTC (38ca89a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-ruby/28/6a6e23b...frivoal:38ca89a.html" title="Last updated on Nov 17, 2025, 4:05 PM UTC (38ca89a)">Diff</a>