### PR TITLE
Give more details on how `auto` works

### DIFF
--- a/explainers/ruby-tts.md
+++ b/explainers/ruby-tts.md
@@ -254,8 +254,15 @@ Its values are:
   or as "should" rather than "must" requirements.
 
 * `auto`: the default state, assumed if the attribute is omitted.
-  Assistive technologies must attempt to automatically determine
-  whether to behave as `complementary` or as `phonetic`.
+  A speech user agents must attempt to automatically determine
+  whether to behave as `complementary` or as `phonetic`:
+  if it can determine
+  that the ruby annotation is a possible pronunciation
+  of the corresponding ruby base,
+  it should behave as `phonetic`;
+  if it can determine that it is not,
+  or if it cannot be sure either way,
+  it should behave as `complementary`.
 
 In all cases, it is understood that the above requirements
 describe the default behavior speech user agents.


### PR DESCRIPTION
Keep it high level, as it is up to the UA to decide how sofisticated an analysis it wants to run to determine whether the annotaiton matches the base a a phonetic reading.

See https://github.com/w3c/html-ruby/issues/31